### PR TITLE
Fix calls to rm to use -f, bypassing eventual -i aliasing

### DIFF
--- a/bin/_ww.sh
+++ b/bin/_ww.sh
@@ -3,12 +3,12 @@
 TEMPFILE="$HOME/.wwtmp"
 
 if [ -f $TEMPFILE ]; then
-    rm $TEMPFILE
+    rm -f $TEMPFILE
 fi
 
 _ww_helper.py "$@"
 
 if [ -f $TEMPFILE ]; then
     source $TEMPFILE
-    rm $TEMPFILE
+    rm -f $TEMPFILE
 fi


### PR DESCRIPTION
In my shell which uses https://github.com/sorin-ionescu/prezto, rm is aliased to rm -i which causes prompts at each `ww` invocation. This PR fixes that